### PR TITLE
NimManager: do not add "nothing" when it is not required

### DIFF
--- a/lib/python/Components/NimManager.py
+++ b/lib/python/Components/NimManager.py
@@ -1487,7 +1487,7 @@ def InitNimManager(nimmgr, update_slots = []):
 	def tunerTypeChanged(nimmgr, configElement, initial=False):
 		fe_id = configElement.fe_id
 		if configElement.value == "nothing":
-			if ("nothing", _("disabled")) not in config.Nims[fe_id].configMode.choices.choices:
+			if "nothing" not in config.Nims[fe_id].configMode.choices.choices.keys():
 				config.Nims[fe_id].configMode.choices.choices.update({"nothing": _("disabled")})
 			config.Nims[fe_id].configMode.value = "nothing"
 			return


### PR DESCRIPTION
config.Nims[fe_id].configMode.choices.choices is a dict so we can check
on keys.